### PR TITLE
Fix login flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Specifically for admins, there are several commands like clone and move that are
 Clone the repo and then run the following command while in the vcl_cli directory:
 
 ```
-sudo gem build vcl.gemspec && sudo gem install ./vcl-0.2.1.gem && sudo gem cleanup vcl
+sudo gem build vcl.gemspec && sudo gem install ./vcl-0.2.2.gem && sudo gem cleanup vcl
 ```
 
 The same command also works to update to a new version.
@@ -30,7 +30,7 @@ Commands:
   vcl activate                                                    # Activates a service version. Options: --service, --version
   vcl clone SERVICE_ID TARGET_SERVICE_ID                          # Clone a service version to another service.
   vcl create_service CUSTOMER_ID SERVICE_NAME DOMAIN ORIGIN       # Create a blank service for a customer.
-  vcl dictionary ACTION DICTIONARY_NAME=none KEY=none VALUE=none  # Manipulate edge dictionaries. Actions: create, delete, list, add, update, remove, list_...
+  vcl dictionary ACTION DICTIONARY_NAME=none KEY=none VALUE=none  # Manipulate edge dictionaries. Actions: create, delete, list, add, update, remove, list_items, bulk_add. Options: --service --version
   vcl diff SERVICE_ID VERSION1 VERSION2                           # Diff two versions on the same service. Options: --generated
   vcl diff_local                                                  # Diff VCL on Fastly with local VCL. Options: --version
   vcl diff_services SERVICE_ID1 VERSION1 SERVICE_ID2 VERSION2     # Diff versions on two different services. Options: --generated
@@ -38,11 +38,13 @@ Commands:
   vcl help [COMMAND]                                              # Describe available commands or one specific command
   vcl login                                                       # Logs into the app. Required before doing anything else.
   vcl move SERVICE_ID TARGET_CUSTOMER                             # Move a service to a new customer
-  vcl open DOMAIN                                                 # Find the service ID for a domain and open the Fastly app. Options: --sierra
+  vcl open DOMAIN                                                 # Find the service ID for a domain and open the Fastly app.
+  vcl purge_all                                                   # Purge all content from a service. Options: --service
   vcl services CUSTOMER_ID                                        # Lists services for a customer.
   vcl upload                                                      # Uploads VCL in the current directory to the service. Options: --version
   vcl version                                                     # Displays version of the VCL gem.
   vcl waf                                                         # Download WAF VCLs
+
 ```
 
 `vcl download` pulls down all vcls for a service and puts them in a directory for the service. Once you navigate into the directory, the context of that service is assumed by several commands. 

--- a/exe/vcl
+++ b/exe/vcl
@@ -14,6 +14,8 @@ class VclAdmin < Thor
     abort "could not parse service id from directory" unless (id || options[:service])
 
     VCL::Fetcher.api_request(:post, "/service/#{id}/purge_all")
+
+    say("Purge all on #{id} completed.")
   end
 
   desc "open DOMAIN", "Find the service ID for a domain and open the Fastly app. Options: --sierra"
@@ -289,7 +291,7 @@ class VclAdmin < Thor
   def move(service_id, customer_id)
     pass = self.ask("This API endpoint requires your app.fastly.com password: ", :echo => false)
 
-    resp = VCL::Fetcher.api_request(:put, "/service/#{service_id}/change_customer/#{customer_id}?password=#{URI.escape(pass)}", :endpoint => :app)
+    resp = VCL::Fetcher.api_request(:put, "/service/#{service_id}/change_customer/#{customer_id}?password=#{url_encode(pass)}", :endpoint => :app)
 
     say("\nService successfully moved to #{customer_id}")
   end
@@ -387,7 +389,7 @@ class VclAdmin < Thor
 
     user = self.ask("Username: ")
     pass = self.ask("Password: ", :echo => false)
-    resp = VCL::Fetcher.api_request(:post, "/login", { :endpoint => :app, body: "user=#{user}&password=#{pass}"})
+    resp = VCL::Fetcher.api_request(:post, "/login", { :endpoint => :app, body: "user=#{url_encode(user)}&password=#{url_encode(pass)}"})
 
     if resp["needs_two_factor_auth"]
       two_factor = true
@@ -403,18 +405,13 @@ class VclAdmin < Thor
     File.open(VCL::COOKIE_JAR , 'w+') {|f| f.write(JSON.dump(VCL::Cookies)) }
 
     say("Login successful!")
-
-    abort unless yes?("Would you like to create an API key for this application so you won't have to login in the future? \nNote: Per-User API keys are a beta Fastly feature and may not be enabled on your account. In order to enable this feature, please email support@fastly.com")
+    say("Creating root scoped token...")
 
     headers = {}
-    if (two_factor)
-      say("\nTwo factor auth enabled on account.")
-      code = ask('Please enter verification code again:', echo: false)
-      headers["Fastly-OTP"] = code
-    end
+    headers["Fastly-OTP"] = code
 
-    VCL::Fetcher.api_request(:post, "/sudo", {force_session: true, :endpoint => :api, body: "username=#{user}&password=#{pass}", headers: headers})
-    resp = VCL::Fetcher.api_request(:post, "/tokens", {force_session: true, :endpoint => :api, body: "name=vcl_cli_token&scope=root&username=#{user}&password=#{pass}", headers: headers})
+    VCL::Fetcher.api_request(:post, "/sudo", {force_session: true, :endpoint => :api, body: "user=#{url_encode(user)}&password=#{url_encode(pass)}", headers: headers})
+    resp = VCL::Fetcher.api_request(:post, "/tokens", {force_session: true, :endpoint => :api, body: "name=vcl_cli_token&scope=root&user=#{url_encode(user)}&password=#{url_encode(pass)}", headers: headers})
 
     token = resp["access_token"]
     token_id = resp["id"]
@@ -423,14 +420,14 @@ class VclAdmin < Thor
 
     File.open(VCL::TOKEN_FILE , 'w+') {|f| f.write(token) }
 
-    resp = VCL::Fetcher.api_request(:get, "/tokens", { force_session: true, headers: {"Fastly-Key" => token}})
+    resp = VCL::Fetcher.api_request(:get, "/tokens", { headers: {"Fastly-Key" => token}})
     abort unless resp.count > 0
 
     resp.each do |t|
       next unless (t["name"] == "vcl_cli_token" && t["id"] != token_id)
 
       if yes?("There was already a token created with the name vcl_cli_token. To avoid creating multiple tokens, should it be deleted?")
-        VCL::Fetcher.api_request(:delete, "/tokens/#{t["id"]}", {headers: {"Fastly-Key" => token}})
+        VCL::Fetcher.api_request(:delete, "/tokens/#{t["id"]}", {headers: {"Fastly-Key" => token}, expected_response: 204})
         say("Token with id #{t["id"]} deleted.")
       end
     end

--- a/exe/vcl
+++ b/exe/vcl
@@ -18,12 +18,11 @@ class VclAdmin < Thor
     say("Purge all on #{id} completed.")
   end
 
-  desc "open DOMAIN", "Find the service ID for a domain and open the Fastly app. Options: --sierra"
-  option :sierra
+  desc "open DOMAIN", "Find the service ID for a domain and open the Fastly app."
   def open(domain)
     id = VCL::Fetcher.domain_to_service_id(domain)
 
-    Launchy.open(VCL::FASTLY_APP + (options[:sierra] ? VCL::SIERRA_PATH : VCL::TANGO_PATH) + id)
+    Launchy.open(VCL::FASTLY_APP + VCL::TANGO_PATH + id)
   end
 
   desc "download VCL_NAME=all", "Download VCLs. Options: --service, --version"

--- a/lib/vcl.rb
+++ b/lib/vcl.rb
@@ -4,16 +4,19 @@ require "diffy"
 require "json"
 require "uri"
 require "launchy"
+require "erb"
 
 require "vcl/version"
 require "vcl/fetcher"
 require "vcl/utils"
 
+include ERB::Util
+
 module VCL
   COOKIE_JAR = ENV['HOME'] + "/vcl_cookie_jar"
   TOKEN_FILE = ENV['HOME'] + "/vcl_token"
   FASTLY_API = "https://api.fastly.com"
-  FASTLY_APP = "https://app.fastly.com"
+  FASTLY_APP = "https://manage.fastly.com"
   TANGO_PATH = "/canary/configure/services/"
   SIERRA_PATH = "/#configure/"
 

--- a/lib/vcl.rb
+++ b/lib/vcl.rb
@@ -17,8 +17,7 @@ module VCL
   TOKEN_FILE = ENV['HOME'] + "/vcl_token"
   FASTLY_API = "https://api.fastly.com"
   FASTLY_APP = "https://manage.fastly.com"
-  TANGO_PATH = "/canary/configure/services/"
-  SIERRA_PATH = "/#configure/"
+  TANGO_PATH = "/configure/services/"
 
   Cookies = File.exist?(VCL::COOKIE_JAR) ? JSON.parse(File.read(VCL::COOKIE_JAR)) : {}
   Token = File.exist?(VCL::TOKEN_FILE) ? File.read(VCL::TOKEN_FILE) : false

--- a/lib/vcl/version.rb
+++ b/lib/vcl/version.rb
@@ -1,3 +1,3 @@
 module VCL
-  VERSION = "0.2.1"
+  VERSION = "0.2.2"
 end


### PR DESCRIPTION
Use Tango
Expect a 204 on DELETE /tokens endpoint
Properly URI encode everything
Default to API always (I had thought this was already the case...)
Add Fastly-API-Request header. Tango throws a fit if you don't have it
Remove the superfluous limited availability language and avoid putting in OTP code twice
