### PR TITLE
Added watch command

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    vcl (1.0.3)
+    vcl (1.0.5)
       bundler (~> 1.10)
       diffy (~> 3.0, >= 3.0.7)
       launchy (~> 2.4.3, >= 2.4.3)

--- a/lib/vcl/cli.rb
+++ b/lib/vcl/cli.rb
@@ -11,6 +11,7 @@ require "vcl/commands/move"
 require "vcl/commands/create_service"
 require "vcl/commands/dictionary"
 require "vcl/commands/login"
+require "vcl/commands/watch"
 
 module VCL
   class CLI < Thor

--- a/lib/vcl/commands/watch.rb
+++ b/lib/vcl/commands/watch.rb
@@ -1,0 +1,36 @@
+module VCL
+  class CLI < Thor
+    desc "watch", "Watch live stats on a service"
+    option :service
+    def watch
+      service = options[:service]
+      service ||= VCL::Utils.parse_directory
+
+      ts = false
+      while true
+        data = VCL::Fetcher.api_request(:get,"/rt/v1/channel/#{service}/ts/#{ts ? ts : 'h/limit/120'}", :endpoint => :app)
+        
+        unless data["Data"].length > 0
+          say("No data to display!")
+          abort
+        end
+
+        agg = data["Data"][0]["aggregated"]
+
+        rps = agg["requests"]
+        # gbps
+        bw = ((agg["resp_header_bytes"] + agg["resp_body_bytes"]).to_f * 8.0) / 1000000000.0
+        hit_rate = (1.0 - ((agg["miss"] - agg["shield"]).to_f / agg["requests"].to_f)) * 100.0
+        passes = agg["pass"]
+        miss_time = ((agg["miss_time"] / agg["miss"]) * 1000).round(0)
+        synth = agg["synth"]
+        errors = agg["errors"]
+
+        $stdout.flush
+        print " #{rps} req/s | #{bw.round(3)}gb/s | #{hit_rate.round(2)}% Hit Ratio | #{passes} passes/s | #{synth} synths/s | #{miss_time}ms miss time | #{errors} errors/s   \r"
+
+        ts = data["Timestamp"]
+      end
+    end
+  end
+end

--- a/lib/vcl/version.rb
+++ b/lib/vcl/version.rb
@@ -1,3 +1,3 @@
 module VCL
-  VERSION = "1.0.4"
+  VERSION = "1.0.5"
 end


### PR DESCRIPTION
Shows current traffic statistics for a service. May assume current directory context or specify service with --service